### PR TITLE
Update Bazel code to account for `rules_nodejs` v5 change

### DIFF
--- a/index.bzl
+++ b/index.bzl
@@ -1,6 +1,6 @@
 """Bazel rules and macros for running tsec over a ng_module or ts_library."""
 
-load("@npm//@bazel/typescript/internal:ts_config.bzl", "TsConfigInfo")
+load("@npm//@bazel/concatjs/internal:ts_config.bzl", "TsConfigInfo")
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "NpmPackageInfo")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")


### PR DESCRIPTION
The `rules_nodejs` v5 package moved the `ts_library`, `ts_project` rules from `@bazel/typescript` to `@bazel/concatjs`.
The majority of users is not using `ts_library` but rather a simpler, less-optimal rule called `ts_project` (hence the
move from `@bazel/typescript` into the rather-legacy concatjs package -- which originates from the old g3 export)

Related https://github.com/angular/angular/pull/45235

@uraj could you potentially help with landing and releasing this to unblock Angular? thanks!