### PR TITLE
Sort diagnostics before reporting

### DIFF
--- a/src/tsec.ts
+++ b/src/tsec.ts
@@ -91,8 +91,10 @@ function main(args: string[]) {
   const result = program.emit();
   diagnostics.push(...result.diagnostics);
 
+  const sortedDiagnostics = ts.sortAndDeduplicateDiagnostics(diagnostics);
+
   const reportDiagnostics = createDiagnosticsReporter(parsedConfig.options);
-  const errorCount = reportDiagnostics(diagnostics, /*withSummary*/ true);
+  const errorCount = reportDiagnostics(sortedDiagnostics, /*withSummary*/ true);
 
   return errorCount === 0 ? 0 : 1;
 }


### PR DESCRIPTION
This PR proposes to call `sortAndDeduplicateDiagnostics()` and sort errors before reporting them back to user. This is helpful when there are large number of errors from many different files. 